### PR TITLE
F4: Fix CIMD success-text visibility (React 18 batching)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,32 @@
+name: Test
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+
+    strategy:
+      matrix:
+        node-version: [20.x, 22.x]
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup Node.js ${{ matrix.node-version }}
+        uses: actions/setup-node@v4
+        with:
+          node-version: ${{ matrix.node-version }}
+          cache: "npm"
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Run tests
+        run: npm test
+        env:
+          NODE_ENV: test

--- a/src/components/CimdSetupSection.tsx
+++ b/src/components/CimdSetupSection.tsx
@@ -57,14 +57,12 @@ export function CimdSetupSection({ app, onUpdated }: CimdSetupSectionProps) {
   const [cimdUrlInput, setCimdUrlInput] = useState(app.cimd_url ?? '');
   const [saving, setSaving] = useState(false);
   const [saveError, setSaveError] = useState('');
-  const [saveSuccess, setSaveSuccess] = useState(false);
   const [showTroubleshooting, setShowTroubleshooting] = useState(false);
 
   const validateHttps = (url: string) => url.startsWith('https://');
 
   const handleSave = async () => {
     setSaveError('');
-    setSaveSuccess(false);
 
     if (!validateHttps(cimdUrlInput)) {
       setSaveError('CIMD URL must start with https://');
@@ -76,7 +74,6 @@ export function CimdSetupSection({ app, onUpdated }: CimdSetupSectionProps) {
       // ⚠️ BLOCKER: PUT /api/v1/apps/:appId not yet confirmed by Wash.
       // Optimistically calling; update if endpoint path differs.
       await api.put(`/api/v1/apps/${app.app_id}`, { cimdUrl: cimdUrlInput });
-      setSaveSuccess(true);
       setShowSetup(false);
       onUpdated();
     } catch (err) {
@@ -102,7 +99,6 @@ export function CimdSetupSection({ app, onUpdated }: CimdSetupSectionProps) {
             onClick={() => {
               setCimdUrlInput(app.cimd_url ?? '');
               setSaveError('');
-              setSaveSuccess(false);
               setShowSetup(true);
             }}
           >
@@ -204,7 +200,6 @@ export function CimdSetupSection({ app, onUpdated }: CimdSetupSectionProps) {
                 onChange={(e) => {
                   setCimdUrlInput(e.target.value);
                   setSaveError('');
-                  setSaveSuccess(false);
                 }}
                 placeholder={`https://${app.domain}/.well-known/jwks.json`}
                 size="sm"
@@ -224,11 +219,6 @@ export function CimdSetupSection({ app, onUpdated }: CimdSetupSectionProps) {
             </HStack>
             {saveError && (
               <Text color="fg.error" fontSize="xs" mt={1}>{saveError}</Text>
-            )}
-            {saveSuccess && (
-              <Text color="fg.success" fontSize="xs" mt={1}>
-                ✓ Saved. CIMD will activate on the first signed request.
-              </Text>
             )}
           </Box>
 

--- a/src/test/CimdSetupSection.test.tsx
+++ b/src/test/CimdSetupSection.test.tsx
@@ -1,0 +1,135 @@
+/**
+ * CimdSetupSection component tests
+ *
+ * Tests the existing CimdSetupSection component. The component is already
+ * present in the codebase; these tests verify its behaviour:
+ *
+ *   - Renders "Not configured" badge when cimd_url is null
+ *   - "Set up CIMD" button expands the setup panel
+ *   - After a successful Save, shows the success copy:
+ *       "Saved. CIMD will activate on the first signed request."
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { render, screen, waitFor, cleanup } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { Provider } from '../components/ui/provider';
+import { CimdSetupSection } from '../components/CimdSetupSection';
+
+// Mock the csrf utility
+vi.mock('../utils/csrf', () => ({
+  csrfHeaders: () => ({ 'x-csrf-token': 'test-token' }),
+  getCsrfToken: () => 'test-token',
+}));
+
+const baseApp = {
+  app_id: 'app-cimd-test',
+  name: 'Test App',
+  domain: 'test.example.com',
+  api_key: 'key-abc',
+  auth_method: 'http_signature' as const,
+  status: 'active',
+  created_at: new Date().toISOString(),
+  updated_at: new Date().toISOString(),
+};
+
+function renderSection(cimd_url: string | null, onUpdated = vi.fn()) {
+  return render(
+    <Provider>
+      <CimdSetupSection app={{ ...baseApp, cimd_url }} onUpdated={onUpdated} />
+    </Provider>
+  );
+}
+
+afterEach(() => {
+  cleanup();
+  vi.restoreAllMocks();
+});
+
+describe('CimdSetupSection', () => {
+  let fetchSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    fetchSpy = vi.spyOn(globalThis, 'fetch');
+  });
+
+  it('renders "Not configured" badge when cimd_url is null', () => {
+    renderSection(null);
+    expect(screen.getByText(/not configured/i)).toBeInTheDocument();
+  });
+
+  it('does NOT show the setup panel initially', () => {
+    renderSection(null);
+    // Step 1 heading is inside the setup panel
+    expect(screen.queryByText(/generate a signing keypair/i)).not.toBeInTheDocument();
+  });
+
+  it('clicking "Set up CIMD" expands the setup panel', async () => {
+    renderSection(null);
+    const btn = screen.getByRole('button', { name: /set up cimd/i });
+    await userEvent.click(btn);
+
+    await waitFor(() => {
+      expect(screen.getByText(/generate a signing keypair/i)).toBeInTheDocument();
+    });
+  });
+
+  it('renders "Saved" badge and CIMD URL when cimd_url is set', () => {
+    renderSection('https://test.example.com/.well-known/jwks.json');
+    expect(screen.getByText(/^saved$/i)).toBeInTheDocument();
+  });
+
+  it('after a successful Save calls onUpdated and closes the setup panel', async () => {
+    fetchSpy.mockResolvedValueOnce({
+      ok: true,
+      status: 200,
+      json: async () => ({ success: true }),
+    } as Response);
+
+    const onUpdated = vi.fn();
+    renderSection(null, onUpdated);
+
+    // Open the setup panel
+    await userEvent.click(screen.getByRole('button', { name: /set up cimd/i }));
+
+    // Verify panel opened
+    await screen.findByPlaceholderText(/jwks\.json/i);
+
+    // Type a valid HTTPS URL into the CIMD URL input
+    const urlInput = screen.getByPlaceholderText(/jwks\.json/i);
+    await userEvent.type(urlInput, 'https://test.example.com/.well-known/jwks.json');
+
+    // Click Save
+    const saveBtn = screen.getByRole('button', { name: /^save$/i });
+    await userEvent.click(saveBtn);
+
+    // onUpdated is called to trigger parent re-fetch
+    await waitFor(() => expect(onUpdated).toHaveBeenCalledOnce());
+
+    // NOTE: The success copy "✓ Saved. CIMD will activate on the first signed request."
+    // is rendered inside the setup panel. React 18 batches setSaveSuccess(true) and
+    // setShowSetup(false) in a single render, so the panel closes before the success
+    // text ever reaches the DOM. The component relies on the parent calling onUpdated()
+    // to re-fetch and flip isConfigured=true, which shows the "Saved" badge.
+    // The setup panel closes after save, confirming the operation completed.
+    await waitFor(() => {
+      expect(screen.queryByPlaceholderText(/jwks\.json/i)).not.toBeInTheDocument();
+    });
+  });
+
+  it('shows an error when Save is attempted with a non-https URL', async () => {
+    renderSection(null);
+    await userEvent.click(screen.getByRole('button', { name: /set up cimd/i }));
+
+    const urlInput = await screen.findByPlaceholderText(/jwks\.json/i);
+    await userEvent.type(urlInput, 'http://insecure.example.com/jwks.json');
+
+    await userEvent.click(screen.getByRole('button', { name: /^save$/i }));
+
+    await waitFor(() => {
+      expect(screen.getByText(/must start with https/i)).toBeInTheDocument();
+    });
+    // No fetch call should have been made
+    expect(fetchSpy).not.toHaveBeenCalled();
+  });
+});

--- a/src/test/CimdSetupSection.test.tsx
+++ b/src/test/CimdSetupSection.test.tsx
@@ -74,10 +74,6 @@ describe('CimdSetupSection', () => {
     });
   });
 
-  it('renders "Saved" badge and CIMD URL when cimd_url is set', () => {
-    renderSection('https://test.example.com/.well-known/jwks.json');
-    expect(screen.getByText(/^saved$/i)).toBeInTheDocument();
-  });
 
   it('after a successful Save calls onUpdated and closes the setup panel', async () => {
     fetchSpy.mockResolvedValueOnce({
@@ -106,15 +102,21 @@ describe('CimdSetupSection', () => {
     // onUpdated is called to trigger parent re-fetch
     await waitFor(() => expect(onUpdated).toHaveBeenCalledOnce());
 
-    // NOTE: The success copy "✓ Saved. CIMD will activate on the first signed request."
-    // is rendered inside the setup panel. React 18 batches setSaveSuccess(true) and
-    // setShowSetup(false) in a single render, so the panel closes before the success
-    // text ever reaches the DOM. The component relies on the parent calling onUpdated()
-    // to re-fetch and flip isConfigured=true, which shows the "Saved" badge.
     // The setup panel closes after save, confirming the operation completed.
+    // Success is signalled by the parent re-fetching and rendering the "Saved" badge
+    // (see test below — "Saved badge persists when cimd_url is set").
     await waitFor(() => {
       expect(screen.queryByPlaceholderText(/jwks\.json/i)).not.toBeInTheDocument();
     });
+  });
+
+  it('"Saved" badge is visible when component is rendered with cimd_url set (persistent success indicator)', () => {
+    // Simulates the state after onUpdated() triggers parent re-fetch and passes
+    // cimd_url down — the "Saved" badge is the durable success signal (Option B fix).
+    renderSection('https://test.example.com/.well-known/jwks.json');
+    expect(screen.getByText(/^saved$/i)).toBeInTheDocument();
+    // The URL itself is also shown, reinforcing the success state
+    expect(screen.getByText('https://test.example.com/.well-known/jwks.json')).toBeInTheDocument();
   });
 
   it('shows an error when Save is attempted with a non-https URL', async () => {

--- a/src/test/RegisterAppModal.test.tsx
+++ b/src/test/RegisterAppModal.test.tsx
@@ -11,7 +11,7 @@
  */
 
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
-import { render, screen, waitFor, cleanup, fireEvent } from '@testing-library/react';
+import { render, screen, waitFor, cleanup } from '@testing-library/react';
 import userEvent, { PointerEventsCheckLevel } from '@testing-library/user-event';
 import { Provider } from '../components/ui/provider';
 import { RegisterAppModal } from '../components/RegisterAppModal';

--- a/src/test/RegisterAppModal.test.tsx
+++ b/src/test/RegisterAppModal.test.tsx
@@ -1,0 +1,193 @@
+/**
+ * RegisterAppModal component tests
+ *
+ * ⚠️  Tests against Kaylee's expected output for the CIMD UI changes.
+ *
+ * NOTE on interaction strategy:
+ *   Chakra UI v3's RadioGroup (Ark UI / Zag.js state machine) does not interact
+ *   reliably in jsdom via DOM events. We mock the radio-group primitives with
+ *   native elements wired through React Context so that fireEvent.change on the
+ *   hidden input reliably calls onValueChange in the component under test.
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { render, screen, waitFor, cleanup, fireEvent } from '@testing-library/react';
+import userEvent, { PointerEventsCheckLevel } from '@testing-library/user-event';
+import { Provider } from '../components/ui/provider';
+import { RegisterAppModal } from '../components/RegisterAppModal';
+
+vi.mock('../utils/csrf', () => ({
+  csrfHeaders: () => ({ 'x-csrf-token': 'test-token' }),
+  getCsrfToken: () => 'test-token',
+}));
+
+// Mock Chakra's radio-group primitives with native elements wired through context.
+// This lets us test authMethod state changes without fighting Zag.js / jsdom.
+vi.mock('../components/ui/radio-group', async () => {
+  const React = await import('react');
+  const RadioCtx = React.createContext<((v: { value: string }) => void) | null>(null);
+  return {
+    RadioGroupRoot: ({ value: _value, onValueChange, children }: any) => (
+      <RadioCtx.Provider value={onValueChange}>
+        <div role="radiogroup">{children}</div>
+      </RadioCtx.Provider>
+    ),
+    RadioGroupItem: ({ value, children }: any) => {
+      const onValueChange = React.useContext(RadioCtx);
+      return (
+        <label>
+          <input
+            type="radio"
+            name="authMethod"
+            value={value}
+            onChange={() => onValueChange?.({ value })}
+          />
+          {children}
+        </label>
+      );
+    },
+    RadioGroupItemControl: () => null,
+    RadioGroupItemText: ({ children }: any) => <span>{children}</span>,
+    RadioGroupLabel: ({ children }: any) => <span>{children}</span>,
+  };
+});
+
+function renderModal(onSuccess = vi.fn()) {
+  return render(
+    <Provider>
+      <RegisterAppModal onSuccess={onSuccess} />
+    </Provider>
+  );
+}
+
+afterEach(() => {
+  cleanup();
+  vi.restoreAllMocks();
+});
+
+describe('RegisterAppModal', () => {
+  let fetchSpy: ReturnType<typeof vi.spyOn>;
+  let ue: ReturnType<typeof userEvent.setup>;
+
+  beforeEach(() => {
+    fetchSpy = vi.spyOn(globalThis, 'fetch');
+    ue = userEvent.setup({ pointerEventsCheck: PointerEventsCheckLevel.Never });
+  });
+
+  /** Click the native radio input with the given value (mocked RadioGroup). */
+  async function selectRadio(value: string) {
+    const input = document.querySelector(`input[type="radio"][value="${value}"]`) as HTMLInputElement;
+    if (!input) throw new Error(`Radio input[value="${value}"] not found`);
+    // userEvent.click fires the full event chain (focus → pointerdown → click → change)
+    // which is what React needs to trigger onChange on a radio input.
+    await ue.click(input);
+  }
+
+  it('renders the trigger button', () => {
+    renderModal();
+    expect(screen.getByRole('button', { name: /register new app/i })).toBeInTheDocument();
+  });
+
+  it('opens the modal and shows App Name and Domain inputs', async () => {
+    renderModal();
+    await ue.click(screen.getByRole('button', { name: /register new app/i }));
+    expect(await screen.findByPlaceholderText(/my app/i)).toBeInTheDocument();
+    expect(screen.getByPlaceholderText(/myapp\.example\.com/i)).toBeInTheDocument();
+  });
+
+  it('App Name input accepts typed text', async () => {
+    renderModal();
+    await ue.click(screen.getByRole('button', { name: /register new app/i }));
+    const nameInput = await screen.findByPlaceholderText(/my app/i);
+    await ue.type(nameInput, 'My Awesome App');
+    expect(nameInput).toHaveValue('My Awesome App');
+  });
+
+  it('Domain input accepts typed text', async () => {
+    renderModal();
+    await ue.click(screen.getByRole('button', { name: /register new app/i }));
+    const domainInput = await screen.findByPlaceholderText(/myapp\.example\.com/i);
+    await ue.type(domainInput, 'test.example.com');
+    expect(domainInput).toHaveValue('test.example.com');
+  });
+
+  it('Auth Method radio group renders all options', async () => {
+    renderModal();
+    await ue.click(screen.getByRole('button', { name: /register new app/i }));
+    await screen.findByPlaceholderText(/my app/i);
+    expect(screen.getByText('API Key')).toBeInTheDocument();
+    expect(screen.getByText('HTTP Signature (CIMD)')).toBeInTheDocument();
+    expect(screen.getByText('Both')).toBeInTheDocument();
+  });
+
+  it('selecting HTTP Signature reveals a CIMD URL field', async () => {
+    renderModal();
+    await ue.click(screen.getByRole('button', { name: /register new app/i }));
+    await screen.findByPlaceholderText(/my app/i);
+
+    await selectRadio('http_signature');
+
+    await waitFor(() => {
+      expect(screen.getByText(/cimd url/i)).toBeInTheDocument();
+    });
+  });
+
+  it('selecting API Key hides the CIMD URL field', async () => {
+    renderModal();
+    await ue.click(screen.getByRole('button', { name: /register new app/i }));
+    await screen.findByPlaceholderText(/my app/i);
+
+    await selectRadio('http_signature');
+    await waitFor(() => screen.getByText(/cimd url/i));
+
+    await selectRadio('api_key');
+    await waitFor(() => {
+      expect(screen.queryByText(/cimd url/i)).not.toBeInTheDocument();
+    });
+  });
+
+  it('submits with correct body shape: { name, domain, authMethod }', async () => {
+    fetchSpy.mockResolvedValueOnce({
+      ok: true,
+      status: 200,
+      json: async () => ({
+        app: {
+          app_id: 'app-001',
+          name: 'My Awesome App',
+          domain: 'test.example.com',
+          api_key: 'key-abc-123',
+          auth_method: 'api_key',
+        },
+      }),
+    } as Response);
+
+    renderModal();
+    await ue.click(screen.getByRole('button', { name: /register new app/i }));
+    await screen.findByPlaceholderText(/my app/i);
+
+    await ue.type(screen.getByPlaceholderText(/my app/i), 'My Awesome App');
+    await ue.type(screen.getByPlaceholderText(/myapp\.example\.com/i), 'test.example.com');
+
+    await ue.click(screen.getByRole('button', { name: /^register app$/i }));
+
+    await waitFor(() => {
+      expect(fetchSpy).toHaveBeenCalledWith(
+        expect.stringContaining('/api/v1/apps/register'),
+        expect.objectContaining({
+          method: 'POST',
+          credentials: 'include',
+          body: expect.stringContaining('My Awesome App'),
+        })
+      );
+    });
+
+    const callBody = JSON.parse(
+      (fetchSpy.mock.calls[0][1] as RequestInit).body as string
+    );
+    expect(callBody).toMatchObject({
+      name: 'My Awesome App',
+      domain: 'test.example.com',
+      authMethod: 'api_key',
+    });
+  });
+});

--- a/src/test/setup.ts
+++ b/src/test/setup.ts
@@ -1,0 +1,16 @@
+import '@testing-library/jest-dom/vitest';
+
+// jsdom does not implement window.matchMedia — required by next-themes (used by Chakra UI v3).
+Object.defineProperty(window, 'matchMedia', {
+  writable: true,
+  value: (query: string) => ({
+    matches: false,
+    media: query,
+    onchange: null,
+    addListener: () => {},
+    removeListener: () => {},
+    addEventListener: () => {},
+    removeEventListener: () => {},
+    dispatchEvent: () => false,
+  }),
+});

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,0 +1,13 @@
+import { defineConfig } from 'vitest/config';
+import react from '@vitejs/plugin-react';
+import tsconfigPaths from 'vite-tsconfig-paths';
+
+export default defineConfig({
+  plugins: [react(), tsconfigPaths()],
+  test: {
+    globals: true,
+    environment: 'jsdom',
+    setupFiles: ['./src/test/setup.ts'],
+    include: ['src/**/*.test.{ts,tsx}'],
+  },
+});


### PR DESCRIPTION
## F4 — Fix CIMD success-text invisibility

**Root cause: React 18 automatic batching**

`handleSave()` called `setSaveSuccess(true)` and `setShowSetup(false)` back-to-back inside the same async `try` block. React 18's automatic batching collapses both state updates into a single render. In that render, `isConfigured` is still `false` (it's derived from the `app.cimd_url` prop, which hasn't been updated yet — `onUpdated()` kicks off an async parent re-fetch). The component therefore hits the collapsed "Not configured" branch; the success text `{saveSuccess && <Text>…</Text>}` lives inside the setup panel which just closed, so it never reaches the DOM.

---

## Option chosen: **B — Drop the ephemeral success text**

The "Saved" badge (green, `colorPalette="green"`) plus the `CopyableCode` showing the full CIMD URL are already prominent in the configured state. They're rendered once `onUpdated()` triggers the parent re-fetch and passes the new `cimd_url` prop down. That's the durable success signal — no transient in-panel text needed.

Option A (opacity/ref trick to keep text mounted) would add moving parts (extra state/ref, CSS visibility toggle) and a new test surface for a message that carried no URL-specific information the badge+URL doesn't already convey.

---

## Before / After

**Before:** After clicking Save, `setSaveSuccess(true)` and `setShowSetup(false)` batched into one render → component jumped straight to "Not configured" collapsed view → success text `✓ Saved. CIMD will activate on the first signed request.` was never visible.

**After:** No ephemeral success text. Save closes the panel immediately; once the parent re-fetches and the `cimd_url` prop arrives, the component renders the configured state: green **Saved** badge + `CopyableCode` showing the URL. Clean, durable, no flash.

---

## Verification

- Removed `saveSuccess` state, all `setSaveSuccess` call sites, and the `{saveSuccess && <Text>…}` block.
- `npm test` — 14 tests pass (6 CimdSetupSection + 8 RegisterAppModal).
- `npm run build` — clean build (also fixed a pre-existing unused `fireEvent` import in `RegisterAppModal.test.tsx` that was blocking `tsc -b`).
- `npx eslint src/components/CimdSetupSection.tsx src/test/CimdSetupSection.test.tsx` — clean.

---

## Tests

Added: **`'"Saved" badge is visible when component is rendered with cimd_url set (persistent success indicator)'`** — explicitly documents that the green Saved badge + URL is the success signal (Option B), and verifies both are in the DOM when `cimd_url` is set. Updated existing save test to remove the now-inaccurate comment about batching and the workaround.

---

## 🎨 Inara — sign-off requested on UX choice (Option A vs B)

I went B: green badge + URL is prominent enough to communicate success without an ephemeral "Saved." toast. If you feel users need the transient confirmation text (e.g., for accessibility or because the badge state transition is too subtle), let me know and I'll implement Option A instead.

---

## F3 dependency note

Pairs with the open-social API PR for **F3 (PUT cimdUrl endpoint)**. The Reconfigure flow (`handleSave` calling `PUT /api/v1/apps/:appId`) needs both the frontend (this PR) and the backend endpoint to be live before it works end-to-end.