### PR TITLE
Fix community page showing Join for existing/pending members

### DIFF
--- a/src/components/CommunityCard.tsx
+++ b/src/components/CommunityCard.tsx
@@ -202,7 +202,11 @@ export function CommunityCard({ membership, onDelete }: CommunityCardProps) {
           )}
 
           <Text fontSize="xs" color="fg.subtle">
-            Joined {new Date(membership.joinedAt).toLocaleDateString()}
+            {status === 'pending'
+              ? 'Membership pending approval'
+              : membership.joinedAt
+                ? `Joined ${new Date(membership.joinedAt).toLocaleDateString()}`
+                : 'Member'}
           </Text>
         </Box>
       </Flex>

--- a/src/pages/CommunityPage.tsx
+++ b/src/pages/CommunityPage.tsx
@@ -185,6 +185,8 @@ export function CommunityPage() {
       if (response.ok) {
         if (data.status === 'already_member') {
           setJoinStatus('already_member');
+          await fetchCommunityDetails();
+          await fetchMembers();
           if (returnTo) {
             setTimeout(() => {
               window.location.href = returnTo;
@@ -213,9 +215,9 @@ export function CommunityPage() {
     }
   }, [did, joining, returnTo, fetchCommunityDetails, fetchMembers]);
 
-  // Auto-join when ?action=join and user is authenticated and not already a member
+  // Auto-join when ?action=join and user is authenticated and not already a member or pending
   useEffect(() => {
-    if (action === 'join' && details && details.isAuthenticated && !details.isMember && !joining && !joinStatus) {
+    if (action === 'join' && details && details.isAuthenticated && !details.isMember && details.membershipStatus !== 'pending' && !joining && !joinStatus) {
       handleJoinCommunity();
     }
   }, [action, details, joining, joinStatus, handleJoinCommunity]);
@@ -576,9 +578,11 @@ export function CommunityPage() {
   const { community, memberCount, isAdmin, userRole } = details;
   const isMember = details.isMember;
   const isAuthenticated = details.isAuthenticated;
+  const membershipStatus = details.membershipStatus;
+  const isPendingMember = isAuthenticated && !isMember && (membershipStatus === 'pending' || joinStatus === 'pending');
 
   // Non-authenticated or non-member view: show community info with join option
-  if (!isAuthenticated || !isMember) {
+  if (!isAuthenticated || (!isMember && !isPendingMember)) {
     return (
       <Box minH="100vh" bg="bg.page">
         {community.banner && (
@@ -714,9 +718,9 @@ export function CommunityPage() {
                   {!returnTo && (
                     <Button
                       colorPalette="accent"
-                      onClick={() => {
-                        // Reload page to show full member view
-                        window.location.reload();
+                      onClick={async () => {
+                        await fetchCommunityDetails();
+                        await fetchMembers();
                       }}
                     >
                       View Community
@@ -784,6 +788,24 @@ export function CommunityPage() {
 
       <Container maxW="container.content" py={{ base: 4, md: 8 }} px={{ base: 4, md: 6 }}>
         <VStack gap={6} align="stretch">
+          {/* Pending membership notice */}
+          {isPendingMember && (
+            <Box
+              bg="orange.50"
+              borderWidth="1px"
+              borderColor="orange.200"
+              borderRadius="lg"
+              p={4}
+              textAlign="center"
+            >
+              <Text fontWeight="semibold" color="orange.700">
+                ⏳ Your membership is pending admin approval
+              </Text>
+              <Text fontSize="sm" color="orange.600" mt={1}>
+                You will have full access once an admin approves your request.
+              </Text>
+            </Box>
+          )}
           {/* Header Section */}
           <Flex
             direction={{ base: 'column', md: 'row' }}

--- a/src/types.ts
+++ b/src/types.ts
@@ -36,6 +36,7 @@ export interface CommunityDetails {
   isAuthenticated: boolean;
   userRole?: string;
   credentialError?: boolean;
+  membershipStatus?: 'active' | 'pending' | null;
 }
 
 export interface Membership {


### PR DESCRIPTION
## Problem

On a community page, existing and pending members see the "Join" message instead of the community view. After clicking Join, the API returns `already_member`, but clicking the "View Community" button triggers `window.location.reload()`, which re-fetches community details from the server. Because `isMember` is still `false` for pending members, the join view renders again, creating an infinite loop. On the homepage, pending memberships display "Joined Invalid Date" due to a missing `joinedAt` value.

Fixes #37

## Changes

### CommunityPage.tsx

- **Refresh state after `already_member`**: The `already_member` branch now calls `fetchCommunityDetails()` and `fetchMembers()` so the component state reflects the server response. Previously this was only done for `joined` status.
- **View Community button**: Replaced `window.location.reload()` with an in-place state refresh (`fetchCommunityDetails` + `fetchMembers`). This breaks the reload loop by updating React state directly instead of discarding it.
- **Pending member gate**: Added `isPendingMember` derived from `details.membershipStatus === "pending"` (server-driven) or `joinStatus === "pending"` (in-session). Pending members now bypass the join view and see the full community page with an orange "pending approval" banner.
- **Auto-join guard**: The `?action=join` effect now checks `details.membershipStatus !== "pending"` to avoid re-triggering join requests for users who already have a pending membership.

### CommunityCard.tsx

- Shows "Membership pending approval" when `status === "pending"` instead of rendering `Joined Invalid Date`.
- Added a guard for missing `joinedAt` values, falling back to "Member".

### types.ts

- Added `membershipStatus?: "active" | "pending" | null` to `CommunityDetails` to carry the server-provided membership state.

## Risks and tradeoffs

- **Pending members see the full community page** with limited functionality (they cannot post or interact as members). This is a deliberate tradeoff: showing community content with a clear "pending approval" banner is a better experience than the join loop. If restricting content visibility for pending members is preferred, a follow-up can gate specific tabs or sections behind `isMember`.
- **Dual pending detection**: `isPendingMember` checks both `membershipStatus` (from the API) and `joinStatus` (from in-session state). This means the pending banner works immediately after submitting a join request (before the page is reloaded), but also persists across page loads once the backend companion change ships. If the backend change ships first, the `joinStatus` fallback becomes redundant but harmless.
- **No new API calls**: The state refresh on "View Community" makes two fetch calls (`fetchCommunityDetails` + `fetchMembers`) that were already being made on page load. No new endpoints or additional network overhead.
- **Hardcoded orange banner colors** (`orange.50`, `orange.200`, `orange.700`) may not fully align with the design system in dark mode. Verified they render acceptably in the current theme, but a design review is recommended.

## Validation

### Automated
- TypeScript compiles cleanly (`tsc -b`, zero errors).
- All 14 existing tests pass (`vitest run`).
- ESLint shows only pre-existing errors (6 `@typescript-eslint/no-explicit-any` warnings in CommunityPage.tsx unrelated to this change, confirmed by running lint on `main`).

### Manual (local dev, backend + frontend)
Tested against a local backend (`open-social` on port 3001) and frontend (`open-social-web` on port 5174) with PostgreSQL via Docker Compose.

1. **Seeded a test community** in the database with `community_type: "admin-approved"` and a row in `pending_members` for the logged-in user.
2. **Visited the community page** (`/communities/did%3Aplc%3Atestcommunity00000001`) while logged in.
3. **Confirmed the pending member banner** renders: the page shows the community view with an orange "Your membership is pending admin approval" banner instead of the Join CTA.
4. **Confirmed the join view still shows for non-members**: visiting the same page in an unauthenticated session shows the Join CTA as expected.


<img width="1326" height="726" alt="Screenshot 2026-05-15 at 22 08 01" src="https://github.com/user-attachments/assets/8fe87c5a-846d-4dba-b9d6-f97ba02a56a0" />




### Not yet tested (requires two ATProto accounts)
- Full join flow: non-member clicks Join on an admin-approved community, sees "Join Request Submitted", reloads, and sees the pending banner.
- `?action=join` share link for a user who is already pending (should not re-trigger join).
- "View Community" button after receiving `already_member` status (should transition to member view without reload loop).
- Homepage CommunityCard showing "Membership pending approval" instead of "Joined Invalid Date".

## Backend companion

This PR works standalone for the in-session flow (joining then clicking "View Community"). For the full fix across page reloads, the backend needs to return `membershipStatus` in `GET /communities/:did`. That change is in [eggyhead/open-social#1](https://github.com/eggyhead/open-social/pull/1).